### PR TITLE
Update item_specific_apis.md

### DIFF
--- a/item_specific_apis.md
+++ b/item_specific_apis.md
@@ -542,7 +542,7 @@ semantic_models = fc.list_semantic_models(workspace_id="1232")
 
 # Create Semantic Model
 semantic_model_w_content = fc.get_semantic_model(workspace_id="1232", semantic_model_name="Table")
-definition = semantic_model_w_content.definition
+definition = semantic_model_w_content.definition['definition']
 semantic_model = fc.create_semantic_model(workspace_id="1232", display_name="semanticmodel1", definition=definition)
 
 # Get Semantic Model


### PR DESCRIPTION
definition = semantic_model_w_content.definition

to 

definition = semantic_model_w_content.definition['definition']

as the previous method didn't referenced the definition correctly and will result in an error when creating a new semantic model