### PR TITLE
Onboard Bulk Shortcuts

### DIFF
--- a/msfabricpysdkcore/client.py
+++ b/msfabricpysdkcore/client.py
@@ -118,6 +118,8 @@ class FabricClient():
                 if wait_for_completion:
                     operation_result = self.long_running_operation(response.headers)
                     if "operation_result" in return_format:
+                        if ("value_json" in return_format and isinstance(operation_result, dict) and "value" in operation_result):
+                            return operation_result["value"]
                         return operation_result
                 return response
             elif response.status_code not in response_codes:

--- a/msfabricpysdkcore/workspace.py
+++ b/msfabricpysdkcore/workspace.py
@@ -325,6 +325,9 @@ class Workspace:
     def create_shortcut(self, item_id, path, name, target):
         return self.core_client.create_shortcut(workspace_id=self.id, item_id=item_id, 
                                                 path=path, name=name, target=target)
+    
+    def create_shortcuts_bulk(self, workspace_id, item_id, create_shortcut_requests):
+        return self.core_client.create_shortcuts_bulk(workspace_id=self.id, item_id=item_id, create_shortcut_requests=create_shortcut_requests)
         
     def delete_shortcut(self, item_id, path, name):
         return self.core_client.delete_shortcut(self.id, item_id, path=path, name=name)


### PR DESCRIPTION
This pull request adds support for bulk creation of OneLake shortcuts and improves the return value handling for long-running operations. The main changes include introducing a new `create_shortcuts_bulk` method in both `coreapi.py` and `workspace.py`, along with input validation, and updating the client logic to return only the value from operation results when requested.

**Bulk shortcut creation support:**

* Added a new `create_shortcuts_bulk` method to `msfabricpysdkcore/coreapi.py` for bulk creation of OneLake shortcuts, including input validation for request structure and required fields.
* Exposed the `create_shortcuts_bulk` functionality in `msfabricpysdkcore/workspace.py` to allow bulk shortcut creation from the workspace interface.

**Improvements to long-running operation handling:**

* Updated `calling_routine` in `msfabricpysdkcore/client.py` to return only the `"value"` field from the operation result when `"value_json"` is specified in the `return_format`, streamlining result handling for API consumers.